### PR TITLE
Add example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,8 @@ println!(
     prop.value_u32_list(&mut buf)
 );
 ```
+
+To run a test sample execute:
+```sh
+cargo run --example dump src/test_dtb/sample.dtb
+```

--- a/examples/dump.rs
+++ b/examples/dump.rs
@@ -1,0 +1,38 @@
+extern crate dtb;
+
+use dtb::{Reader, StructItem};
+use std::fs;
+use std::io::Read;
+
+fn main() {
+    let mut buf = Vec::new();
+    let mut file = fs::File::open(
+        std::env::args()
+            .nth(1)
+            .expect("Need path to DTB file as argument"),
+    )
+    .unwrap();
+    file.read_to_end(&mut buf).unwrap();
+    let reader = Reader::read(buf.as_slice()).unwrap();
+
+    for entry in reader.reserved_mem_entries() {
+        println!("reserved: {:?} bytes at {:?}", entry.size, entry.address);
+    }
+
+    let mut indent = 0;
+    for entry in reader.struct_items() {
+        match entry {
+            StructItem::BeginNode { name } => {
+                println!("{:indent$}{} {{", "", name, indent = indent);
+                indent += 2;
+            }
+            StructItem::EndNode => {
+                indent -= 2;
+                println!("{:indent$}}}", "", indent = indent);
+            }
+            StructItem::Property { name, value } => {
+                println!("{:indent$}{}: {:?}", "", name, value, indent = indent)
+            }
+        }
+    }
+}


### PR DESCRIPTION
Add a simple example file that will print entire DTB structure as an example.

Add invocation help to README.