### PR TITLE
Read DTB from memory location

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,6 @@ license = "MIT"
 name = "dtb"
 readme = "README.md"
 repository = "https://github.com/ababo/dtb"
-version = "0.1.3"
+version = "0.2.0"
 
 [dependencies]

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -445,6 +445,12 @@ impl<'a> Reader<'a> {
             addr as *const u8,
             header.total_size as usize,
         );
+
+        // Additionally validate new-size memory blob against header size.
+        if blob.len() < size_of::<Header>() {
+            return Err(Error::UnexpectedEndOfBlob);
+        }
+
         Ok(Reader::<'a> {
             reserved_mem: Reader::get_reserved_mem(blob, &header)?,
             struct_block: Reader::get_struct_block(blob, &header)?,

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -104,8 +104,8 @@ impl<'a> StructItems<'a> {
             .position(|&ch| ch == 0)
             .ok_or(Error::BadPropertyName)?;
 
-        let name = from_utf8(&string_start[..pos + 1])
-            .map_err(Error::BadStrEncoding)?;
+        let name =
+            from_utf8(&string_start[..=pos]).map_err(Error::BadStrEncoding)?;
         self.set_offset(offset);
 
         Ok(StructItem::Property { name, value })

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -419,9 +419,7 @@ impl<'a> Reader<'a> {
         let header = Reader::get_header(blob)?;
 
         // Additionally validate the header against known file size.
-        if header.total_size != blob.len() as u32
-            || header.total_size as usize != blob.len()
-        {
+        if header.total_size as usize != blob.len() {
             return Err(Error::BadTotalSize);
         }
 


### PR DESCRIPTION
My OS uses dtb to parse passed in device-tree and the usual boot protocol only gives you a starting memory location of the DTB.

This PR adds `Reader::read_from_memory_address(addr: usize)` for use exactly in this kernel scenario.

Bumped minor version according to semver.

The test `reader::tests::test_bad_property_name` has already been failing before implementing this  change, needs to be fixed separately.